### PR TITLE
增加多目标牌概率计算

### DIFF
--- a/components/hypergeometric/index.tsx
+++ b/components/hypergeometric/index.tsx
@@ -1,336 +1,69 @@
 'use client';
 
 import { useState } from 'react';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Button } from '@/components/ui/button';
-
-interface CalculatorInput {
-  populationSize: number;      // 牌库大小
-  sampleSize: number;          // 抽牌数量
-  successesInPopulation: number; // 目标牌数量
-  successesInSample: number;   // 想抽到的目标牌数量
-}
-
-interface ProbabilityResults {
-  exact: number;
-  orMore: number;
-  orLess: number;
-  zero: number;
-}
-
-function calculateHypergeometric(input: CalculatorInput, targetSuccesses: number): number {
-  const { populationSize, sampleSize, successesInPopulation } = input;
-  
-  // 检查输入是否有效
-  if (
-    populationSize < 0 || 
-    sampleSize < 0 || 
-    successesInPopulation < 0 || 
-    targetSuccesses < 0 ||
-    sampleSize > populationSize ||
-    successesInPopulation > populationSize ||
-    targetSuccesses > successesInPopulation ||
-    targetSuccesses > sampleSize
-  ) {
-    return 0;
-  }
-
-  // 计算组合数的函数
-  function combinations(n: number, k: number): number {
-    if (k > n) return 0;
-    if (k === 0 || k === n) return 1;
-    
-    let result = 1;
-    for (let i = 1; i <= k; i++) {
-      result *= (n - i + 1) / i;
-    }
-    return result;
-  }
-
-  // 超几何分布公式
-  const numerator = combinations(successesInPopulation, targetSuccesses) * 
-                   combinations(populationSize - successesInPopulation, sampleSize - targetSuccesses);
-  const denominator = combinations(populationSize, sampleSize);
-  
-  return numerator / denominator;
-}
-
-function calculateAllProbabilities(input: CalculatorInput): ProbabilityResults {
-  const exact = calculateHypergeometric(input, input.successesInSample);
-  
-  let orMore = 0;
-  for (let i = input.successesInSample; i <= Math.min(input.successesInPopulation, input.sampleSize); i++) {
-    orMore += calculateHypergeometric({ ...input, successesInSample: i }, i);
-  }
-
-  let orLess = 0;
-  for (let i = 0; i <= input.successesInSample; i++) {
-    orLess += calculateHypergeometric({ ...input, successesInSample: i }, i);
-  }
-
-  const zero = calculateHypergeometric({ ...input, successesInSample: 0 }, 0);
-
-  return { exact, orMore, orLess, zero };
-}
-
-const quickInputs = {
-  populationSize: [40, 60],
-  sampleSize: [7, 8, 9],
-  successesInPopulation: [4, 17, 24],
-  successesInSample: [1, 2, 3, 4],
-};
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { SingleCardCalculator } from './single-card';
+import { MultiCardCalculator } from './multi-card';
+import type { CalculatorInput } from './single-card';
+import type { MultiCardInput } from './multi-card';
 
 export function HypergeometricCalculator() {
-  const [values, setValues] = useState<CalculatorInput>({
+  const [tab, setTab] = useState('single');
+  
+  // 单牌计算器状态
+  const [singleCardValues, setSingleCardValues] = useState<CalculatorInput>({
     populationSize: 60,
     sampleSize: 7,
     successesInPopulation: 4,
     successesInSample: 1,
   });
 
-  const [probabilities, setProbabilities] = useState<ProbabilityResults | null>(null);
-
-  const handleChange = (id: keyof CalculatorInput, value: string) => {
-    // 如果输入为空，使用0
-    if (!value) {
-      setValues(prev => ({ ...prev, [id]: 0 }));
-      return;
-    }
-
-    // 处理数字转换
-    const numValue = parseInt(value);
-    if (!isNaN(numValue)) {
-      setValues(prev => ({ ...prev, [id]: numValue }));
-    }
-    setProbabilities(null);
-  };
-
-  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
-    e.target.select();
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    // 如果当前值为0，且输入的是数字，则清空输入框
-    const input = e.currentTarget;
-    if (input.value === '0' && e.key >= '0' && e.key <= '9') {
-      input.value = '';
-    }
-  };
-
-  const handleCalculate = () => {
-    const probs = calculateAllProbabilities(values);
-    setProbabilities(probs);
-  };
-
-  const handleQuickInput = (field: keyof typeof quickInputs, value: number) => {
-    setValues(prev => ({ ...prev, [field]: value }));
-    setProbabilities(null);
-  };
+  // 多牌计算器状态
+  const [multiCardValues, setMultiCardValues] = useState<MultiCardInput>({
+    populationSize: 60,
+    sampleSize: 7,
+    targetCards: [
+      {
+        id: '1',
+        name: '目标牌1',
+        count: 4,
+        expected: 1
+      }
+    ]
+  });
 
   return (
-    <div className="grid gap-8 md:grid-cols-2">
-      {/* 输入区域 */}
-      <div className="border border-[--border] rounded-lg p-6 bg-[--card] h-fit">
-        <h2 className="text-xl font-semibold mb-4">输入参数</h2>
-
-        <div className="space-y-4">
-          <div className="space-y-1.5">
-            <div className="flex items-center justify-between mb-1">
-              <div>
-                <Label className="text-base font-medium">牌库总数</Label>
-                <div className="text-xs text-gray-500 mt-0.5">
-                  你的牌库中的总牌数
-                </div>
-              </div>
-              <div className="space-y-1">
-                <Input
-                  type="number"
-                  value={values.populationSize}
-                  onChange={(e) => handleChange('populationSize', e.target.value)}
-                  min={0}
-                  className="w-20 text-lg text-right"
-                  onFocus={handleFocus}
-                  onKeyDown={handleKeyDown}
-                />
-                <div className="flex gap-1 justify-end">
-                  {quickInputs.populationSize.map(value => (
-                    <Button
-                      key={value}
-                      size="sm"
-                      variant="secondary"
-                      className="px-2 h-7 bg-[--accent] hover:bg-[--accent]/80"
-                      onClick={() => handleQuickInput('populationSize', value)}
-                    >
-                      {value}
-                    </Button>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="space-y-1.5">
-            <div className="flex items-center justify-between mb-1">
-              <div>
-                <Label className="text-base font-medium">抽牌数量</Label>
-                <div className="text-xs text-gray-500 mt-0.5">
-                  要抽的牌数，例如起手牌数
-                </div>
-              </div>
-              <div className="space-y-1">
-                <Input
-                  type="number"
-                  value={values.sampleSize}
-                  onChange={(e) => handleChange('sampleSize', e.target.value)}
-                  min={0}
-                  className="w-20 text-lg text-right"
-                  onFocus={handleFocus}
-                  onKeyDown={handleKeyDown}
-                />
-                <div className="flex gap-1 justify-end">
-                  {quickInputs.sampleSize.map(value => (
-                    <Button
-                      key={value}
-                      size="sm"
-                      variant="secondary"
-                      className="px-2 h-7 bg-[--accent] hover:bg-[--accent]/80"
-                      onClick={() => handleQuickInput('sampleSize', value)}
-                    >
-                      {value}
-                    </Button>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="space-y-1.5">
-            <div className="flex items-center justify-between mb-1">
-              <div>
-                <Label className="text-base font-medium">目标牌数量</Label>
-                <div className="text-xs text-gray-500 mt-0.5">
-                  牌库中你想要找的牌的数量
-                </div>
-              </div>
-              <div className="space-y-1">
-                <Input
-                  type="number"
-                  value={values.successesInPopulation}
-                  onChange={(e) => handleChange('successesInPopulation', e.target.value)}
-                  min={0}
-                  className="w-20 text-lg text-right"
-                  onFocus={handleFocus}
-                  onKeyDown={handleKeyDown}
-                />
-                <div className="flex gap-1 justify-end">
-                  {quickInputs.successesInPopulation.map(value => (
-                    <Button
-                      key={value}
-                      size="sm"
-                      variant="secondary"
-                      className="px-2 h-7 bg-[--accent] hover:bg-[--accent]/80"
-                      onClick={() => handleQuickInput('successesInPopulation', value)}
-                    >
-                      {value}
-                    </Button>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="space-y-1.5">
-            <div className="flex items-center justify-between mb-1">
-              <div>
-                <Label className="text-base font-medium">期望抽到数量</Label>
-                <div className="text-xs text-gray-500 mt-0.5">
-                  你想要抽到多少张目标牌
-                </div>
-              </div>
-              <div className="space-y-1">
-                <Input
-                  type="number"
-                  value={values.successesInSample}
-                  onChange={(e) => handleChange('successesInSample', e.target.value)}
-                  min={0}
-                  className="w-20 text-lg text-right"
-                  onFocus={handleFocus}
-                  onKeyDown={handleKeyDown}
-                />
-                <div className="flex gap-1 justify-end">
-                  {quickInputs.successesInSample.map(value => (
-                    <Button
-                      key={value}
-                      size="sm"
-                      variant="secondary"
-                      className="px-2 h-7 bg-[--accent] hover:bg-[--accent]/80"
-                      onClick={() => handleQuickInput('successesInSample', value)}
-                    >
-                      {value}
-                    </Button>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <Button 
-            onClick={handleCalculate} 
-            className="w-full text-lg py-6 mt-6 bg-[--primary] text-[--primary-foreground] hover:bg-[--primary]/90"
+    <div className="space-y-6">
+      <Tabs value={tab} onValueChange={setTab} className="w-full">
+        <TabsList className="grid w-full sm:w-fit grid-cols-2 h-11 p-0.5 bg-[--accent]/50">
+          <TabsTrigger 
+            value="single" 
+            className="px-8 text-base data-[state=active]:bg-[--background] data-[state=active]:text-[--foreground] data-[state=active]:shadow-none"
           >
-            计算概率
-          </Button>
-        </div>
-      </div>
+            单牌概率
+          </TabsTrigger>
+          <TabsTrigger 
+            value="multi" 
+            className="px-8 text-base data-[state=active]:bg-[--background] data-[state=active]:text-[--foreground] data-[state=active]:shadow-none"
+          >
+            多牌概率
+          </TabsTrigger>
+        </TabsList>
 
-      {/* 结果区域 */}
-      <div className="border border-[--border] rounded-lg p-6 bg-[--card] h-fit">
-        <h2 className="text-xl font-semibold mb-6">计算结果</h2>
-        {probabilities ? (
-          <div className="grid gap-6">
-            <div className="p-4 rounded-lg bg-[--accent] border border-[--border]">
-              <div className="text-base text-[--muted-foreground] mb-1">
-                抽到 {values.successesInSample} 张或更多目标牌的概率
-              </div>
-              <div className="text-3xl font-bold text-[--primary]">
-                {(probabilities.orMore * 100).toPrecision(3)}%
-              </div>
-            </div>
+        <TabsContent value="single" className="mt-6">
+          <SingleCardCalculator 
+            values={singleCardValues}
+            onChange={setSingleCardValues}
+          />
+        </TabsContent>
 
-            <div className="p-4 rounded-lg bg-[--accent] border border-[--border]">
-              <div className="text-base text-[--muted-foreground] mb-1">
-                抽到恰好 {values.successesInSample} 张目标牌的概率
-              </div>
-              <div className="text-3xl font-bold text-[--primary]">
-                {(probabilities.exact * 100).toPrecision(3)}%
-              </div>
-            </div>
-
-            <div className="p-4 rounded-lg bg-[--accent] border border-[--border]">
-              <div className="text-base text-[--muted-foreground] mb-1">
-                抽到 {values.successesInSample} 张或更少目标牌的概率
-              </div>
-              <div className="text-3xl font-bold text-[--primary]">
-                {(probabilities.orLess * 100).toPrecision(3)}%
-              </div>
-            </div>
-
-            <div className="p-4 rounded-lg bg-[--accent] border border-[--border]">
-              <div className="text-base text-[--muted-foreground] mb-1">
-                一张目标牌都抽不到的概率
-              </div>
-              <div className="text-3xl font-bold text-[--primary]">
-                {(probabilities.zero * 100).toPrecision(3)}%
-              </div>
-            </div>
-          </div>
-        ) : (
-          <div className="text-center text-[--muted-foreground] py-12">
-            输入参数并点击计算按钮查看结果
-          </div>
-        )}
-      </div>
+        <TabsContent value="multi" className="mt-6">
+          <MultiCardCalculator 
+            values={multiCardValues}
+            onChange={setMultiCardValues}
+          />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 } 

--- a/components/hypergeometric/multi-card.tsx
+++ b/components/hypergeometric/multi-card.tsx
@@ -1,0 +1,370 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Plus, X } from 'lucide-react';
+
+interface TargetCard {
+  id: string;
+  name: string;
+  count: number;
+  expected: number;
+}
+
+export interface MultiCardInput {
+  populationSize: number;      // 牌库大小
+  sampleSize: number;          // 抽牌数量
+  targetCards: TargetCard[];   // 目标牌列表
+}
+
+interface MultiCardProbabilities {
+  all: number;          // 同时抽到所有目标牌的概率
+  atLeastOne: number;   // 至少抽到一种目标牌的概率
+  individual: {         // 每种牌单独的概率
+    id: string;
+    name: string;
+    probability: number;
+  }[];
+}
+
+interface MultiCardCalculatorProps {
+  values: MultiCardInput;
+  onChange: (values: MultiCardInput) => void;
+}
+
+// 计算组合数 C(n,k)
+function combinations(n: number, k: number): number {
+  if (k > n) return 0;
+  if (k === 0 || k === n) return 1;
+  
+  let result = 1;
+  for (let i = 1; i <= k; i++) {
+    result *= (n - i + 1) / i;
+  }
+  return result;
+}
+
+export function MultiCardCalculator({ values, onChange }: MultiCardCalculatorProps) {
+  const [probabilities, setProbabilities] = useState<MultiCardProbabilities | null>(null);
+
+  const handleChange = (field: keyof MultiCardInput, value: string) => {
+    if (field === 'populationSize' || field === 'sampleSize') {
+      const numValue = parseInt(value) || 0;
+      onChange({ ...values, [field]: numValue });
+    }
+    setProbabilities(null);
+  };
+
+  const handleTargetCardChange = (id: string, field: keyof TargetCard, value: string) => {
+    onChange({
+      ...values,
+      targetCards: values.targetCards.map(card => {
+        if (card.id === id) {
+          if (field === 'name') {
+            return { ...card, [field]: value };
+          } else {
+            return { ...card, [field]: parseInt(value) || 0 };
+          }
+        }
+        return card;
+      })
+    });
+    setProbabilities(null);
+  };
+
+  const handleAddCard = () => {
+    const newCardIndex = values.targetCards.length + 1;
+    onChange({
+      ...values,
+      targetCards: [
+        ...values.targetCards,
+        {
+          id: Date.now().toString(),
+          name: `目标牌${newCardIndex}`,
+          count: 4,
+          expected: 1
+        }
+      ]
+    });
+    setProbabilities(null);
+  };
+
+  const handleRemoveCard = (id: string) => {
+    onChange({
+      ...values,
+      targetCards: values.targetCards.filter(card => card.id !== id)
+    });
+    setProbabilities(null);
+  };
+
+  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    e.target.select();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const input = e.currentTarget;
+    if (input.value === '0' && e.key >= '0' && e.key <= '9') {
+      input.value = '';
+    }
+  };
+
+  const handleCalculate = () => {
+    // 计算每种牌的单独概率
+    const individual = values.targetCards.map(card => {
+      let probability = 0;
+      const { count, expected } = card;
+      
+      // 计算至少抽到期望数量的概率
+      for (let i = expected; i <= Math.min(count, values.sampleSize); i++) {
+        probability += (
+          combinations(count, i) * 
+          combinations(values.populationSize - count, values.sampleSize - i) / 
+          combinations(values.populationSize, values.sampleSize)
+        );
+      }
+
+      return {
+        id: card.id,
+        name: card.name,
+        probability
+      };
+    });
+
+    // 使用包含-排除原理计算多张牌的概率
+    const n = values.targetCards.length;
+    let all = 0;
+    let atLeastOne = 0;
+    
+    // 生成所有可能的抽牌组合
+    const generateCombinations = (current: number[], depth: number, remainingSize: number): number => {
+      // 如果已经处理完所有牌
+      if (depth === n) {
+        // 检查是否满足所有期望
+        const meetsAll = current.every((count, idx) => count >= values.targetCards[idx].expected);
+        const meetsOne = current.some((count, idx) => count >= values.targetCards[idx].expected);
+        
+        // 计算当前组合的概率
+        const otherCards = values.populationSize - values.targetCards.reduce((sum, card) => sum + card.count, 0);
+        let prob = 1;
+        
+        // 计算每种牌的组合数
+        for (let i = 0; i < n; i++) {
+          prob *= combinations(values.targetCards[i].count, current[i]);
+        }
+        
+        // 计算剩余牌的组合数
+        prob *= combinations(otherCards, remainingSize);
+        prob /= combinations(values.populationSize, values.sampleSize);
+        
+        if (meetsAll) all += prob;
+        if (meetsOne) atLeastOne += prob;
+        return prob;
+      }
+      
+      // 递归生成组合
+      let sum = 0;
+      const card = values.targetCards[depth];
+      const maxPossible = Math.min(card.count, remainingSize);
+      
+      for (let i = 0; i <= maxPossible; i++) {
+        current[depth] = i;
+        sum += generateCombinations(current, depth + 1, remainingSize - i);
+      }
+      
+      return sum;
+    };
+
+    // 开始计算
+    const initialCounts = new Array(n).fill(0);
+    generateCombinations(initialCounts, 0, values.sampleSize);
+
+    setProbabilities({
+      all,
+      atLeastOne,
+      individual
+    });
+  };
+
+  return (
+    <div className="grid gap-8 md:grid-cols-2">
+      {/* 输入区域 */}
+      <div className="border border-[--border] rounded-lg p-6 bg-[--card] h-fit">
+        <h2 className="text-xl font-semibold mb-4">输入参数</h2>
+
+        {/* 基础参数 */}
+        <div className="space-y-4 mb-6">
+          <h3 className="text-base font-medium text-[--muted-foreground]">基础参数</h3>
+          
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between mb-1">
+              <div>
+                <Label className="text-base font-medium">牌库总数</Label>
+                <div className="text-xs text-gray-500 mt-0.5">
+                  你的牌库中的总牌数
+                </div>
+              </div>
+              <Input
+                type="number"
+                value={values.populationSize}
+                onChange={(e) => handleChange('populationSize', e.target.value)}
+                min={0}
+                className="w-20 text-lg text-right"
+                onFocus={handleFocus}
+                onKeyDown={handleKeyDown}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between mb-1">
+              <div>
+                <Label className="text-base font-medium">抽牌数量</Label>
+                <div className="text-xs text-gray-500 mt-0.5">
+                  要抽的牌数，例如起手牌数
+                </div>
+              </div>
+              <Input
+                type="number"
+                value={values.sampleSize}
+                onChange={(e) => handleChange('sampleSize', e.target.value)}
+                min={0}
+                className="w-20 text-lg text-right"
+                onFocus={handleFocus}
+                onKeyDown={handleKeyDown}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* 目标牌列表 */}
+        <div className="space-y-6">
+          <div className="flex items-center justify-between border-b border-[--border] pb-2">
+            <h3 className="text-base font-medium">目标牌</h3>
+            <Button
+              className="h-9 px-8 bg-[--primary] text-[--primary-foreground] hover:bg-[--primary]/90"
+              onClick={handleCalculate}
+            >
+              计算概率
+            </Button>
+          </div>
+
+          {values.targetCards.map((card) => (
+            <div
+              key={card.id}
+              className="p-5 rounded-lg border border-[--border] bg-[--accent]/30 space-y-5 hover:border-[--border]/80 transition-colors"
+            >
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex-1">
+                  <Label className="text-sm mb-1.5 block text-[--muted-foreground]">牌名</Label>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      value={card.name}
+                      onChange={(e) => handleTargetCardChange(card.id, 'name', e.target.value)}
+                      className="bg-[--background]"
+                      placeholder="输入牌名"
+                    />
+                    {values.targetCards.length > 1 && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-9 w-9 p-0 hover:bg-red-500/10 hover:text-red-500 shrink-0"
+                        onClick={() => handleRemoveCard(card.id)}
+                      >
+                        <X className="w-5 h-5" />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-5">
+                <div>
+                  <Label className="text-sm mb-1.5 block text-[--muted-foreground]">牌库中的数量</Label>
+                  <Input
+                    type="number"
+                    value={card.count}
+                    onChange={(e) => handleTargetCardChange(card.id, 'count', e.target.value)}
+                    min={0}
+                    className="bg-[--background]"
+                    onFocus={handleFocus}
+                    onKeyDown={handleKeyDown}
+                  />
+                </div>
+                <div>
+                  <Label className="text-sm mb-1.5 block text-[--muted-foreground]">期望抽到数量</Label>
+                  <Input
+                    type="number"
+                    value={card.expected}
+                    onChange={(e) => handleTargetCardChange(card.id, 'expected', e.target.value)}
+                    min={0}
+                    className="bg-[--background]"
+                    onFocus={handleFocus}
+                    onKeyDown={handleKeyDown}
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+
+          <Button
+            size="sm"
+            variant="secondary"
+            className="w-full h-8"
+            onClick={handleAddCard}
+          >
+            <Plus className="w-4 h-4 mr-1.5" />
+            添加目标牌
+          </Button>
+        </div>
+      </div>
+
+      {/* 结果区域 */}
+      <div className="border border-[--border] rounded-lg p-6 bg-[--card] h-fit">
+        <h2 className="text-xl font-semibold mb-6">计算结果</h2>
+        {probabilities ? (
+          <div className="grid gap-6">
+            <div className="p-4 rounded-lg bg-[--accent] border border-[--border]">
+              <div className="text-base text-[--muted-foreground] mb-1">
+                同时抽到所有目标牌的概率
+              </div>
+              <div className="text-3xl font-bold text-[--primary]">
+                {(probabilities.all * 100).toFixed(2)}%
+              </div>
+            </div>
+
+            <div className="p-4 rounded-lg bg-[--accent] border border-[--border]">
+              <div className="text-base text-[--muted-foreground] mb-1">
+                至少抽到一种目标牌的概率
+              </div>
+              <div className="text-3xl font-bold text-[--primary]">
+                {(probabilities.atLeastOne * 100).toFixed(2)}%
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              {probabilities.individual.map(item => (
+                <div
+                  key={item.id}
+                  className="p-4 rounded-lg bg-[--accent] border border-[--border]"
+                >
+                  <div className="text-sm text-[--muted-foreground] mb-1">
+                    抽到{item.name}的概率
+                  </div>
+                  <div className="text-2xl font-bold text-[--primary]">
+                    {(item.probability * 100).toFixed(2)}%
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="text-center text-[--muted-foreground] py-12">
+            输入参数并点击计算按钮查看结果
+          </div>
+        )}
+      </div>
+    </div>
+  );
+} 

--- a/components/hypergeometric/single-card.tsx
+++ b/components/hypergeometric/single-card.tsx
@@ -1,0 +1,345 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+
+export interface CalculatorInput {
+  populationSize: number;      // 牌库大小
+  sampleSize: number;          // 抽牌数量
+  successesInPopulation: number; // 目标牌数量
+  successesInSample: number;   // 想抽到的目标牌数量
+}
+
+interface ProbabilityResults {
+  exact: number;
+  orMore: number;
+  orLess: number;
+  zero: number;
+}
+
+function calculateHypergeometric(input: CalculatorInput, targetSuccesses: number): number {
+  const { populationSize, sampleSize, successesInPopulation } = input;
+  
+  // 检查输入是否有效
+  if (
+    populationSize < 0 || 
+    sampleSize < 0 || 
+    successesInPopulation < 0 || 
+    targetSuccesses < 0 ||
+    sampleSize > populationSize ||
+    successesInPopulation > populationSize ||
+    targetSuccesses > successesInPopulation ||
+    targetSuccesses > sampleSize
+  ) {
+    return 0;
+  }
+
+  // 计算组合数的函数
+  function combinations(n: number, k: number): number {
+    if (k > n) return 0;
+    if (k === 0 || k === n) return 1;
+    
+    let result = 1;
+    for (let i = 1; i <= k; i++) {
+      result *= (n - i + 1) / i;
+    }
+    return result;
+  }
+
+  // 超几何分布公式
+  const numerator = combinations(successesInPopulation, targetSuccesses) * 
+                   combinations(populationSize - successesInPopulation, sampleSize - targetSuccesses);
+  const denominator = combinations(populationSize, sampleSize);
+  
+  return numerator / denominator;
+}
+
+function calculateAllProbabilities(input: CalculatorInput): ProbabilityResults {
+  const { successesInSample } = input;
+  
+  // 计算恰好抽到指定数量的概率
+  const exact = calculateHypergeometric(input, successesInSample);
+  
+  // 计算抽到至少指定数量的概率
+  let orMore = 0;
+  for (let i = successesInSample; i <= Math.min(input.successesInPopulation, input.sampleSize); i++) {
+    orMore += calculateHypergeometric(input, i);
+  }
+  
+  // 计算抽到不超过指定数量的概率
+  let orLess = 0;
+  for (let i = 0; i <= successesInSample; i++) {
+    orLess += calculateHypergeometric(input, i);
+  }
+  
+  // 计算一张都抽不到的概率
+  const zero = calculateHypergeometric(input, 0);
+  
+  return {
+    exact,
+    orMore,
+    orLess,
+    zero
+  };
+}
+
+const quickInputs = {
+  populationSize: [40, 60],
+  sampleSize: [7, 8, 9],
+  successesInPopulation: [4, 17, 24],
+  successesInSample: [1, 2, 3, 4],
+};
+
+interface SingleCardCalculatorProps {
+  values: CalculatorInput;
+  onChange: (values: CalculatorInput) => void;
+}
+
+export function SingleCardCalculator({ values, onChange }: SingleCardCalculatorProps) {
+  const [probabilities, setProbabilities] = useState<ProbabilityResults | null>(null);
+
+  const handleChange = (id: keyof CalculatorInput, value: string) => {
+    // 如果输入为空，使用0
+    if (!value) {
+      onChange({ ...values, [id]: 0 });
+      return;
+    }
+
+    // 处理数字转换
+    const numValue = parseInt(value);
+    if (!isNaN(numValue)) {
+      onChange({ ...values, [id]: numValue });
+    }
+    setProbabilities(null);
+  };
+
+  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    e.target.select();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // 如果当前值为0，且输入的是数字，则清空输入框
+    const input = e.currentTarget;
+    if (input.value === '0' && e.key >= '0' && e.key <= '9') {
+      input.value = '';
+    }
+  };
+
+  const handleCalculate = () => {
+    const probs = calculateAllProbabilities(values);
+    setProbabilities(probs);
+  };
+
+  const handleQuickInput = (field: keyof typeof quickInputs, value: number) => {
+    onChange({ ...values, [field]: value });
+    setProbabilities(null);
+  };
+
+  return (
+    <div className="grid gap-8 md:grid-cols-2">
+      {/* 输入区域 */}
+      <div className="border border-[--border] rounded-lg p-6 bg-[--card] h-fit">
+        <h2 className="text-xl font-semibold mb-4">输入参数</h2>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between mb-1">
+              <div>
+                <Label className="text-base font-medium">牌库总数</Label>
+                <div className="text-xs text-gray-500 mt-0.5">
+                  你的牌库中的总牌数
+                </div>
+              </div>
+              <div className="space-y-1">
+                <Input
+                  type="number"
+                  value={values.populationSize}
+                  onChange={(e) => handleChange('populationSize', e.target.value)}
+                  min={0}
+                  className="w-20 text-lg text-right"
+                  onFocus={handleFocus}
+                  onKeyDown={handleKeyDown}
+                />
+                <div className="flex gap-1 justify-end">
+                  {quickInputs.populationSize.map(value => (
+                    <Button
+                      key={value}
+                      size="sm"
+                      variant="secondary"
+                      className="px-2 h-7 bg-[--accent] hover:bg-[--accent]/80"
+                      onClick={() => handleQuickInput('populationSize', value)}
+                    >
+                      {value}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between mb-1">
+              <div>
+                <Label className="text-base font-medium">抽牌数量</Label>
+                <div className="text-xs text-gray-500 mt-0.5">
+                  要抽的牌数，例如起手牌数
+                </div>
+              </div>
+              <div className="space-y-1">
+                <Input
+                  type="number"
+                  value={values.sampleSize}
+                  onChange={(e) => handleChange('sampleSize', e.target.value)}
+                  min={0}
+                  className="w-20 text-lg text-right"
+                  onFocus={handleFocus}
+                  onKeyDown={handleKeyDown}
+                />
+                <div className="flex gap-1 justify-end">
+                  {quickInputs.sampleSize.map(value => (
+                    <Button
+                      key={value}
+                      size="sm"
+                      variant="secondary"
+                      className="px-2 h-7 bg-[--accent] hover:bg-[--accent]/80"
+                      onClick={() => handleQuickInput('sampleSize', value)}
+                    >
+                      {value}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between mb-1">
+              <div>
+                <Label className="text-base font-medium">目标牌数量</Label>
+                <div className="text-xs text-gray-500 mt-0.5">
+                  牌库中你想要找的牌的数量
+                </div>
+              </div>
+              <div className="space-y-1">
+                <Input
+                  type="number"
+                  value={values.successesInPopulation}
+                  onChange={(e) => handleChange('successesInPopulation', e.target.value)}
+                  min={0}
+                  className="w-20 text-lg text-right"
+                  onFocus={handleFocus}
+                  onKeyDown={handleKeyDown}
+                />
+                <div className="flex gap-1 justify-end">
+                  {quickInputs.successesInPopulation.map(value => (
+                    <Button
+                      key={value}
+                      size="sm"
+                      variant="secondary"
+                      className="px-2 h-7 bg-[--accent] hover:bg-[--accent]/80"
+                      onClick={() => handleQuickInput('successesInPopulation', value)}
+                    >
+                      {value}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between mb-1">
+              <div>
+                <Label className="text-base font-medium">期望抽到数量</Label>
+                <div className="text-xs text-gray-500 mt-0.5">
+                  你想要抽到多少张目标牌
+                </div>
+              </div>
+              <div className="space-y-1">
+                <Input
+                  type="number"
+                  value={values.successesInSample}
+                  onChange={(e) => handleChange('successesInSample', e.target.value)}
+                  min={0}
+                  className="w-20 text-lg text-right"
+                  onFocus={handleFocus}
+                  onKeyDown={handleKeyDown}
+                />
+                <div className="flex gap-1 justify-end">
+                  {quickInputs.successesInSample.map(value => (
+                    <Button
+                      key={value}
+                      size="sm"
+                      variant="secondary"
+                      className="px-2 h-7 bg-[--accent] hover:bg-[--accent]/80"
+                      onClick={() => handleQuickInput('successesInSample', value)}
+                    >
+                      {value}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <Button
+            className="w-full mt-6"
+            onClick={handleCalculate}
+          >
+            计算概率
+          </Button>
+        </div>
+      </div>
+
+      {/* 结果区域 */}
+      <div className="border border-[--border] rounded-lg p-6 bg-[--card] h-fit">
+        <h2 className="text-xl font-semibold mb-6">计算结果</h2>
+        {probabilities ? (
+          <div className="grid gap-6">
+            <div className="p-4 rounded-lg bg-[--accent] border border-[--border]">
+              <div className="text-base text-[--muted-foreground] mb-1">
+                抽到 {values.successesInSample} 张或更多目标牌的概率
+              </div>
+              <div className="text-3xl font-bold text-[--primary]">
+                {(probabilities.orMore * 100).toPrecision(3)}%
+              </div>
+            </div>
+
+            <div className="p-4 rounded-lg bg-[--accent] border border-[--border]">
+              <div className="text-base text-[--muted-foreground] mb-1">
+                抽到恰好 {values.successesInSample} 张目标牌的概率
+              </div>
+              <div className="text-3xl font-bold text-[--primary]">
+                {(probabilities.exact * 100).toPrecision(3)}%
+              </div>
+            </div>
+
+            <div className="p-4 rounded-lg bg-[--accent] border border-[--border]">
+              <div className="text-base text-[--muted-foreground] mb-1">
+                抽到 {values.successesInSample} 张或更少目标牌的概率
+              </div>
+              <div className="text-3xl font-bold text-[--primary]">
+                {(probabilities.orLess * 100).toPrecision(3)}%
+              </div>
+            </div>
+
+            <div className="p-4 rounded-lg bg-[--accent] border border-[--border]">
+              <div className="text-base text-[--muted-foreground] mb-1">
+                一张目标牌都抽不到的概率
+              </div>
+              <div className="text-3xl font-bold text-[--primary]">
+                {(probabilities.zero * 100).toPrecision(3)}%
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="text-center text-[--muted-foreground] py-12">
+            输入参数并点击计算按钮查看结果
+          </div>
+        )}
+      </div>
+    </div>
+  );
+} 

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+export function Tabs({
+  value,
+  onValueChange,
+  children,
+  className = '',
+}: {
+  value: string;
+  onValueChange: (value: string) => void;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <TabsPrimitive.Root
+      value={value}
+      onValueChange={onValueChange}
+      className={className}
+    >
+      {children}
+    </TabsPrimitive.Root>
+  );
+}
+
+export function TabsList({
+  children,
+  className = '',
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <TabsPrimitive.List
+      className={`inline-flex h-10 items-center justify-center rounded-lg bg-[--card] border border-[--border] p-1 text-[--muted-foreground] ${className}`}
+    >
+      {children}
+    </TabsPrimitive.List>
+  );
+}
+
+export function TabsTrigger({
+  value,
+  children,
+  className = '',
+}: {
+  value: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <TabsPrimitive.Trigger
+      value={value}
+      className={`
+        inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-[--background] data-[state=active]:text-[--foreground] data-[state=active]:shadow-sm
+        ${className}
+      `}
+    >
+      {children}
+    </TabsPrimitive.Trigger>
+  );
+}
+
+export function TabsContent({
+  value,
+  children,
+  className = '',
+}: {
+  value: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <TabsPrimitive.Content
+      value={value}
+      className={`mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${className}`}
+    >
+      {children}
+    </TabsPrimitive.Content>
+  );
+} 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slider": "^1.2.1",
+    "@radix-ui/react-tabs": "^1.1.1",
     "date-fns": "^4.1.0",
     "keyrune": "^3.16.0",
     "lucide-react": "^0.462.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@radix-ui/react-slider':
         specifier: ^1.2.1
         version: 1.2.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -427,8 +430,43 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-id@1.1.0':
+    resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.1':
+    resolution: {integrity: sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.0.0':
     resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.0':
+    resolution: {integrity: sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -460,6 +498,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.1':
+    resolution: {integrity: sha512-3GBUDmP2DvzmtYLMsHmpA1GtR46ZDZ+OreXM/N+kkQJOPIgytFWWTfDQmBQKBvaFS0Vno0FktdbVzN28KGrMdw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.0':
@@ -2288,9 +2339,43 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.12
 
+  '@radix-ui/react-id@1.1.0(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@radix-ui/react-presence@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
   '@radix-ui/react-primitive@2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-roving-focus@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.12)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -2322,6 +2407,22 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.12
+
+  '@radix-ui/react-tabs@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
 
   '@radix-ui/react-use-callback-ref@1.1.0(@types/react@18.3.12)(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
feat: 重构超几何计算器支持单牌和多牌计算

- 将原有的超几何计算器拆分为单牌和多牌两个独立组件
- 使用Tabs组件实现切换功能
- 添加@radix-ui/react-tabs依赖