### PR TITLE
更新活动日历

### DIFF
--- a/data/events.ts
+++ b/data/events.ts
@@ -13,19 +13,12 @@ export interface Event {
 }
 
 export const calendarMetadata: CalendarMetadata = {
-  lastUpdated: '2024/12/02',
-  announcementUrl: 'https://magic.wizards.com/en/news/mtg-arena/mtg-arena-announcements-december-2-2024#schedule',
+  lastUpdated: '2024/12/09',
+  announcementUrl: 'https://magic.wizards.com/en/news/mtg-arena/mtg-arena-announcements-december-9-2024#schedule',
 };
 
 export const events: Event[] = [
   // 周中万智牌
-  {
-    type: 'midweek_magic',
-    title: '万智牌：基石构筑争锋构筑挑战',
-    startTime: new Date('2024-12-03T14:00:00-08:00'),
-    endTime: new Date('2024-12-05T14:00:00-08:00'),
-    format: '争锋',
-  },
   {
     type: 'midweek_magic',
     title: '探险构筑',
@@ -46,6 +39,13 @@ export const events: Event[] = [
     startTime: new Date('2024-12-24T14:00:00-08:00'),
     endTime: new Date('2024-12-26T14:00:00-08:00'),
     format: '探险',
+  },
+  {
+    type: 'midweek_magic',
+    title: '万智牌：基石构筑幻影现开',
+    startTime: new Date('2024-12-31T14:00:00-08:00'),
+    endTime: new Date('2025-01-02T14:00:00-08:00'),
+    format: '现开',
   },
   // 竞技轮抽
   {
@@ -95,17 +95,17 @@ export const events: Event[] = [
   // 其他活动
   {
     type: 'other',
-    title: '永恒环境挑战赛',
-    startTime: new Date('2024-12-06T08:00:00-08:00'),
-    endTime: new Date('2024-12-08T08:00:00-08:00'),
-    format: '永恒',
-  },
-  {
-    type: 'other',
     title: '探险环境挑战赛',
     startTime: new Date('2024-12-20T08:00:00-08:00'),
     endTime: new Date('2024-12-22T08:00:00-08:00'),
     format: '探险',
+  },
+  {
+    type: 'other',
+    title: '标准环境挑战赛',
+    startTime: new Date('2025-01-03T08:00:00-08:00'),
+    endTime: new Date('2025-01-05T08:00:00-08:00'),
+    format: '标准',
   },
 
   // 资格赛

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -48,6 +48,7 @@ export const formatSpeedOptions: Option[] = [
 
 // 系列选项
 export const expansionOptions: Option[] = [
+  { label: "PIO", value: "PIO" },
   { label: "FDN", value: "FDN" },
   { label: "DSK", value: "DSK" },
   { label: "Y25DSK", value: "Y25DSK" },

--- a/lib/store/card.ts
+++ b/lib/store/card.ts
@@ -22,7 +22,7 @@ export const useCardStore = create<CardStore>((set) => ({
   cards: [],
   chineseCards: {},
   params: {
-    expansion: 'FDN',
+    expansion: 'PIO',
     format: 'PremierDraft', 
     start_date: '2016-01-01',
     end_date: today,


### PR DESCRIPTION
更新活动日历和系统配置

- 更新活动日历至 12月9日
- 添加新系列 PIO 支持
- 更新默认系列为 PIO
- 删除过期活动
- 新增幻影现开和标准环境挑战赛活动