### PR TITLE
Fix typos in digital set names and update card list identifiers

### DIFF
--- a/data/digital-sets.json
+++ b/data/digital-sets.json
@@ -11,13 +11,13 @@
       "releaseDate": "2024-12-11"
     },
     {
-      "name": "乙太漂移",
+      "name": "乙太飘移",
       "code": "DFT",
       "releaseDate": "2025-2-12",
       "wikiUrl": "https://mtg.fandom.com/wiki/Aetherdrift?utm_source=shiqidi",
       "preview": {
         "title": "扣紧护带",
-        "description": "甩开对手！上车加入乙太漂移，参与这场跨越三个时空、让肾上腺素飙升的多重宇宙竞速赛。",
+        "description": "甩开对手！上车加入乙太飘移，参与这场跨越三个时空、让肾上腺素飙升的多重宇宙竞速赛。",
         "backgroundImage": "/image/DFT_sma_key_1920x1080_en.jpg",
         "links": [
           {

--- a/data/events.ts
+++ b/data/events.ts
@@ -41,7 +41,7 @@ const midweekMagicEvents: Event[] = [
   },
   {
     type: 'midweek_magic',
-    title: '投身乙太漂移',
+    title: '投身乙太飘移',
     startTime: new Date('2025-02-11T14:00:00-08:00'),
     endTime: new Date('2025-02-12T14:00:00-08:00'),
     format: '预组',


### PR DESCRIPTION
- Corrected the name "乙太漂移" to "乙太飘移" in digital-sets.json and events.ts.
- Updated card list identifiers from "plst:VIS-152" to "plst:VIS-152i" in sealed_basic_data.json for consistency.