### PR TITLE
Update MTG Arena event schedule for late January and February 2025

### DIFF
--- a/data/events.ts
+++ b/data/events.ts
@@ -13,18 +13,11 @@ export interface Event {
 }
 
 export const calendarMetadata: CalendarMetadata = {
-  lastUpdated: '2025/01/20',
-  announcementUrl: 'https://magic.wizards.com/en/news/mtg-arena/mtg-arena-announcements-january-20-2025#schedule',
+  lastUpdated: '2025/01/27',
+  announcementUrl: 'https://magic.wizards.com/en/news/mtg-arena/announcements-january-27-2025#schedule',
 };
 
 const midweekMagicEvents: Event[] = [
-  {
-    type: 'midweek_magic',
-    title: '倾曳争锋',
-    startTime: new Date('2025-01-21T14:00:00-08:00'),
-    endTime: new Date('2025-01-23T14:00:00-08:00'),
-    format: '争锋',
-  },
   {
     type: 'midweek_magic',
     title: '史迹纯铁',
@@ -36,15 +29,22 @@ const midweekMagicEvents: Event[] = [
     type: 'midweek_magic',
     title: '黄金包现开赛',
     startTime: new Date('2025-02-04T14:00:00-08:00'),
-    endTime: new Date('2025-02-05T14:00:00-08:00'),
+    endTime: new Date('2025-02-06T14:00:00-08:00'),
     format: '现开',
   },
   {
     type: 'midweek_magic',
     title: '投身乙太飘移',
     startTime: new Date('2025-02-11T14:00:00-08:00'),
-    endTime: new Date('2025-02-12T14:00:00-08:00'),
+    endTime: new Date('2025-02-13T14:00:00-08:00'),
     format: '预组',
+  },
+  {
+    type: 'midweek_magic',
+    title: '乙太飘移构筑',
+    startTime: new Date('2025-02-18T14:00:00-08:00'),
+    endTime: new Date('2025-02-20T14:00:00-08:00'),
+    format: '乙太飘移',
   },
 ];
 
@@ -92,36 +92,44 @@ const quickDraftEvents: Event[] = [
 const otherEvents: Event[] = [
   {
     type: 'other',
-    title: '竞技场直邮赛 - 暮悲邸：鬼屋惊魂',
-    startTime: new Date('2025-01-24T08:00:00-08:00'),
-    endTime: new Date('2025-01-27T08:00:00-08:00'),
-    format: '现开',
-  },
-  {
-    type: 'other',
-    title: '五彩方盒轮抽',
+    title: '五彩方盒Cube轮抽',
     startTime: new Date('2025-01-28T08:00:00-08:00'),
     endTime: new Date('2025-02-11T08:00:00-08:00'),
     format: '轮抽',
-    description: '提供BO1和BO3两种模式',
+    description: '提供BO1和BO3两种模式，卡表见https://magic.wizards.com/en/news/mtg-arena/chromatic-cube-draft',
+  },
+  {
+    type: 'other',
+    title: '史迹环境挑战赛',
+    startTime: new Date('2025-02-21T08:00:00-08:00'),
+    endTime: new Date('2025-02-23T08:00:00-08:00'),
+    format: '史迹',
   },
 ];
 
 const premierPlayEvents: Event[] = [
   {
     type: 'premier_play',
+    title: '资格赛入围赛BO1',
+    startTime: new Date('2025-02-15T06:00:00-08:00'),
+    endTime: new Date('2025-02-16T03:00:00-08:00'),
+    format: '史迹',
+    description: '单日赛事，玩家将竞争获得本月资格赛周末的参赛资格。',
+  },
+  {
+    type: 'premier_play',
     title: '资格赛入围赛BO3',
-    startTime: new Date('2025-01-24T06:00:00-08:00'),
-    endTime: new Date('2025-01-25T03:00:00-08:00'),
-    format: '探险',
+    startTime: new Date('2025-02-21T06:00:00-08:00'),
+    endTime: new Date('2025-02-22T03:00:00-08:00'),
+    format: '史迹',
     description: '单日赛事，玩家将竞争获得本月资格赛周末的参赛资格。',
   },
   {
     type: 'premier_play',
     title: '资格赛周末',
-    startTime: new Date('2025-01-25T06:00:00-08:00'),
-    endTime: new Date('2025-01-26T16:00:00-08:00'),
-    format: '探险',
+    startTime: new Date('2025-02-22T06:00:00-08:00'),
+    endTime: new Date('2025-02-23T16:00:00-08:00'),
+    format: '史迹',
     description: '两日赛事，获胜者将获得参加即将到来的竞技场冠军赛的资格。',
   },
 ];


### PR DESCRIPTION
- Refresh calendar metadata with new announcement URL
- Remove "倾曳争锋" Midweek Magic event
- Extend end times for "黄金包现开赛" and "投身乙太飘移" events
- Add new "乙太飘移构筑" Midweek Magic event
- Update Other Events with "五彩方盒Cube轮抽" and new "史迹环境挑战赛"
- Modify Premier Play events to reflect new dates and formats