### PR TITLE
Update speed data fetching and event schedule

### DIFF
--- a/app/speed/page.tsx
+++ b/app/speed/page.tsx
@@ -1,5 +1,6 @@
 import { SpeedChart } from '@/components/speed/speed-chart';
 import { generateMetadata } from '../metadata';
+import speedData from './speed-data.json';
 
 export const metadata = generateMetadata(
   "十七地 - 轮抽赛制速度",
@@ -10,19 +11,7 @@ export const metadata = generateMetadata(
   }
 );
 
-async function getSpeedData() {
-  const response = await fetch('https://www.17lands.com/data/play_draw', {
-    next: { revalidate: 3600 }
-  });
-  if (!response.ok) {
-    throw new Error('Failed to fetch speed data');
-  }
-  return response.json();
-}
-
-export default async function SpeedPage() {
-  const data = await getSpeedData();
-
+export default function SpeedPage() {
   return (
     <div className="py-8">
       <div className="container mx-auto px-4">
@@ -43,7 +32,7 @@ export default async function SpeedPage() {
             17Lands
           </a>
         </div>
-        <SpeedChart initialData={data} />
+        <SpeedChart initialData={speedData} />
       </div>
     </div>
   );

--- a/data/events.ts
+++ b/data/events.ts
@@ -20,13 +20,6 @@ export const calendarMetadata: CalendarMetadata = {
 const midweekMagicEvents: Event[] = [
   {
     type: 'midweek_magic',
-    title: '史迹纯铁',
-    startTime: new Date('2025-01-28T14:00:00-08:00'),
-    endTime: new Date('2025-01-30T14:00:00-08:00'),
-    format: '史迹',
-  },
-  {
-    type: 'midweek_magic',
     title: '黄金包现开赛',
     startTime: new Date('2025-02-04T14:00:00-08:00'),
     endTime: new Date('2025-02-06T14:00:00-08:00'),
@@ -51,13 +44,6 @@ const midweekMagicEvents: Event[] = [
 const premierDraftEvents: Event[] = [
   {
     type: 'premier_draft',
-    title: '暮悲邸：鬼屋惊魂',
-    startTime: new Date('2025-01-21T08:00:00-08:00'),
-    endTime: new Date('2025-01-28T08:00:00-08:00'),
-    format: '竞技轮抽',
-  },
-  {
-    type: 'premier_draft',
     title: '光雷驿镖客',
     startTime: new Date('2025-01-28T08:00:00-08:00'),
     endTime: new Date('2025-02-04T08:00:00-08:00'),
@@ -70,21 +56,35 @@ const premierDraftEvents: Event[] = [
     endTime: new Date('2025-02-11T08:00:00-08:00'),
     format: '竞技轮抽',
   },
+  {
+    type: 'premier_draft',
+    title: '乙太飘移',
+    startTime: new Date('2025-02-11T08:00:00-08:00'),
+    endTime: new Date('2025-04-08T08:00:00-08:00'),
+    format: '竞技轮抽',
+  },
 ];
 
 const quickDraftEvents: Event[] = [
   {
     type: 'quick_draft',
-    title: '艾卓仙踪',
-    startTime: new Date('2025-01-18T08:00:00-08:00'),
-    endTime: new Date('2025-02-01T08:00:00-08:00'),
+    title: '班隆洛',
+    startTime: new Date('2025-02-01T08:00:00-08:00'),
+    endTime: new Date('2025-02-15T08:00:00-08:00'),
     format: '快速轮抽',
   },
   {
     type: 'quick_draft',
-    title: '班隆洛',
-    startTime: new Date('2025-02-01T08:00:00-08:00'),
-    endTime: new Date('2025-02-15T08:00:00-08:00'),
+    title: '光雷驿镖客',
+    startTime: new Date('2025-02-15T08:00:00-08:00'),
+    endTime: new Date('2025-02-25T08:00:00-08:00'),
+    format: '快速轮抽',
+  },
+  {
+    type: 'quick_draft',
+    title: '乙太飘移',
+    startTime: new Date('2025-02-25T08:00:00-08:00'),
+    endTime: new Date('2025-03-07T08:00:00-08:00'),
     format: '快速轮抽',
   },
 ];
@@ -96,7 +96,7 @@ const otherEvents: Event[] = [
     startTime: new Date('2025-01-28T08:00:00-08:00'),
     endTime: new Date('2025-02-11T08:00:00-08:00'),
     format: '轮抽',
-    description: '提供BO1和BO3两种模式，卡表见https://magic.wizards.com/en/news/mtg-arena/chromatic-cube-draft',
+    description: '提供BO1和BO3两种模式，卡表：https://magic.wizards.com/en/news/mtg-arena/chromatic-cube-draft',
   },
   {
     type: 'other',

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node scripts/fetch-speed-data.js",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/scripts/fetch-speed-data.js
+++ b/scripts/fetch-speed-data.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+async function fetchSpeedData() {
+  return new Promise((resolve, reject) => {
+    https.get('https://www.17lands.com/data/play_draw', (res) => {
+      let data = '';
+
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+
+      res.on('end', () => {
+        try {
+          const jsonData = JSON.parse(data);
+          resolve(jsonData);
+        } catch (e) {
+          reject(e);
+        }
+      });
+    }).on('error', (err) => {
+      reject(err);
+    });
+  });
+}
+
+async function main() {
+  try {
+    console.log('Fetching speed data...');
+    const data = await fetchSpeedData();
+    
+    // 确保目录存在
+    const dir = path.join(__dirname, '../app/speed');
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    // 写入数据
+    fs.writeFileSync(
+      path.join(dir, 'speed-data.json'),
+      JSON.stringify(data, null, 2)
+    );
+    
+    console.log('Speed data has been saved successfully!');
+  } catch (error) {
+    console.error('Error fetching speed data:', error);
+    process.exit(1);
+  }
+}
+
+main(); 


### PR DESCRIPTION
- Add prebuild script to fetch speed data from 17Lands
- Modify SpeedPage to use pre-fetched speed data from JSON
- Update MTG Arena event schedule with new draft and quick draft events
- Remove outdated events from midweek magic and premier draft sections