### PR TITLE
Update Scryfall script page download link behavior

### DIFF
--- a/app/script/page.tsx
+++ b/app/script/page.tsx
@@ -34,7 +34,8 @@ export default function ScriptPage() {
             <div className="flex gap-4">
               <a 
                 href="/scryfall.user.js"
-                download="scryfall.user.js"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="px-4 py-2 rounded-md bg-[--primary] text-[--primary-foreground] hover:opacity-90 transition-opacity"
               >
                 直接安装


### PR DESCRIPTION
- Change script download link to open in a new tab
- Remove download attribute to allow direct browser handling
- Improve link accessibility with target and rel attributes