### PR TITLE
Update Universes Beyond set names and codes in rotation data

### DIFF
--- a/data/rotation.json
+++ b/data/rotation.json
@@ -408,7 +408,7 @@
       "rough_exit_date": "Q1 2028"
     },
     {
-      "name": "Universes Beyond: Final Fantasy",
+      "name": "Magic: The Gathering—FINAL FANTASY",
       "codename": null,
       "block": null,
       "code": "FIN",
@@ -428,7 +428,7 @@
       "rough_exit_date": "Q1 2028"
     },
     {
-      "name": "Universes Beyond: Marvel's Spider-Man",
+      "name": "Marvel’s Spider-Man",
       "codename": null,
       "block": null,
       "code": "SPM",
@@ -438,10 +438,10 @@
       "rough_exit_date": "Q1 2028"
     },
     {
-      "name": null,
-      "codename": "UUB",
+      "name": "Avatar: The Last Airbender",
+      "codename": null,
       "block": null,
-      "code": null,
+      "code": "TLA",
       "enter_date": null,
       "rough_enter_date": "Q4 2025",
       "exit_date": null,


### PR DESCRIPTION
- Rename "Universes Beyond: Final Fantasy" to "Magic: The Gathering—FINAL FANTASY"
- Simplify "Universes Beyond: Marvel's Spider-Man" to "Marvel's Spider-Man"
- Add name and code for "Avatar: The Last Airbender" set (code: TLA)