### PR TITLE
优化卡牌预览页面和组件展示细节

### DIFF
--- a/app/previews/page.tsx
+++ b/app/previews/page.tsx
@@ -63,7 +63,10 @@ export default async function PreviewsPage() {
                     </div>
                   </div>
                   <div className="text-sm text-[--muted-foreground] flex-shrink-0">
-                    {set.cards.length} 张卡牌
+                    {set.total_cards && set.cards.length === set.total_cards
+                      ? `共 ${set.total_cards} 张卡牌`
+                      : `${set.cards.length} / ${set.total_cards || '?'} 张卡牌`
+                    }
                   </div>
                 </div>
               </Link>

--- a/components/mana-text.tsx
+++ b/components/mana-text.tsx
@@ -23,4 +23,4 @@ export function ManaText({ text, className = '' }: ManaTextProps) {
       dangerouslySetInnerHTML={{ __html: processedText }}
     />
   );
-} 
+}

--- a/components/previews/preview-card.tsx
+++ b/components/previews/preview-card.tsx
@@ -162,7 +162,6 @@ export function PreviewCard({ card, isEnglish, logoCode }: PreviewCardProps) {
       <div className="p-4 flex-1 flex flex-col min-w-0">
         <div className="flex items-start gap-4">
           <div className="flex items-center gap-1.5 min-w-0 flex-1">
-            <i className={`ss ${getRarityIcon(card.rarity)} ss-fw ss-2x ss-${logoCode}`} />
             <div className="font-medium break-words leading-none pt-0.5">
               {card.zhs_name === card.name ? (
                 <h3>{card.name}</h3>
@@ -185,8 +184,9 @@ export function PreviewCard({ card, isEnglish, logoCode }: PreviewCardProps) {
         </div>
 
         <div className="mt-4 flex-1 divide-y divide-[--border]">
-          <div className="text-sm pb-2">
+          <div className="text-sm pb-2 flex items-center justify-between">
             <ManaText text={isEnglish ? card.type : card.zhs_type} />
+            <i className={`ss ${getRarityIcon(card.rarity)} ss-fw ss-3x ss-${logoCode}`} />
           </div>
           <div className="text-sm whitespace-pre-wrap pt-2 leading-normal">
             {renderText(isEnglish ? card.text : card.zhs_text)}

--- a/components/previews/preview-content.tsx
+++ b/components/previews/preview-content.tsx
@@ -21,11 +21,19 @@ export function PreviewContent({ previewData, setName }: PreviewContentProps) {
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-3">
             <h1 className="text-2xl font-bold">{setName}预览</h1>
-            {isReleased && (
-              <span className="inline-flex items-center px-2 py-1 text-xs bg-[--primary] text-[--primary-foreground] rounded">
-                已上线
+            <div className="flex items-center gap-2">
+              {isReleased && (
+                <span className="inline-flex items-center px-2 py-1 text-xs bg-[--primary] text-[--primary-foreground] rounded">
+                  已上线
+                </span>
+              )}
+              <span className="inline-flex items-center px-2 py-1 text-xs bg-[--card] text-[--muted-foreground] rounded border border-[--border]">
+                {previewData.total_cards && previewData.cards.length === previewData.total_cards
+                  ? `共 ${previewData.total_cards} 张卡牌`
+                  : `${previewData.cards.length} / ${previewData.total_cards || '?'} 张卡牌`
+                }
               </span>
-            )}
+            </div>
           </div>
           <Button
             variant="secondary"

--- a/data/previews/YDFT.json
+++ b/data/previews/YDFT.json
@@ -1,6 +1,7 @@
 {
   "code": "YDFT",
   "name": "炼金：乙太飘移",
+  "total_cards": 30,
   "logo_code": "y25",
   "release_date": "2025-03-05",
   "description": "炼金：乙太飘移共30张卡牌，将于2025年3月5日上线万智牌：竞技场。感谢轻脚翻译并制作中文卡图。",
@@ -47,7 +48,16 @@
       "zhs_text": "飞行，警戒\n当此载具进场时，派出四个1/1无色自动机衍生神器生物。\n每当此载具攻击时，从支援空锻机的法术书中发现一张牌。该牌永久成为神器生物。\n搭载4",
       "image_url_en": "https://media.wizards.com/2025/y25-dft/en_96393_Printed__SupportSkyforge.webp",
       "image_url_zh": "/image/alchemy/ydft/支援空锻机.png",
-      "spellbook": [],
+      "spellbook": [
+        "DFT:1",
+        "NEC:159",
+        "KLD:233",
+        "NEO:247",
+        "AER:153",
+        "AER:142",
+        "DFT:47",
+        "NEC:160"
+      ],
       "pow_tough": "4/4"
     },
     {

--- a/types/previews.ts
+++ b/types/previews.ts
@@ -23,4 +23,5 @@ export interface PreviewSet {
   release_date: string;
   cards: PreviewCard[];
   description: string;
+  total_cards?: number;
 } 


### PR DESCRIPTION
- 在预览页面和内容组件中添加总卡牌数量显示
- 调整预览卡牌组件的稀有度图标位置和大小
- 为 YDFT 系列数据添加总卡牌数量字段
- 更新预览卡牌组件的布局和展示样式