### PR TITLE
为系列选项添加 Y25DFT 扩展类型

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -49,6 +49,7 @@ export const formatSpeedOptions: Option[] = [
 // 系列选项
 export const expansionOptions: Option[] = [
   { label: "DFT", value: "DFT" },
+  { label: "Y25DFT", value: "Y25DFT" },
   { label: "PIO", value: "PIO" },
   { label: "FDN", value: "FDN" },
   { label: "DSK", value: "DSK" },


### PR DESCRIPTION
- 在 expansionOptions 数组中新增 Y25DFT 选项
- 保持与现有扩展类型一致的格式和结构