### PR TITLE
更新 mastery.ts 和相关文件以反映新的赛季设置

### DIFF
--- a/data/mastery.ts
+++ b/data/mastery.ts
@@ -3,13 +3,13 @@
  */
 export const masteryConfig = {
   // 系列代号
-  setCode: 'DFT',
+  setCode: 'TDM',
   // 当前赛季开始日期（UTC）
-  startDate: '2025-02-11',
+  startDate: '2025-04-08',
   // 当前赛季结束日期（UTC）
-  endDate: '2025-04-08',
+  endDate: '2025-06-10',
   // 最高等级
-  maxLevel: 60,
+  maxLevel: 70,
   // 默认每日胜场数
   defaultDailyWins: 4,
   // 默认每周胜场数

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -48,6 +48,7 @@ export const formatSpeedOptions: Option[] = [
 
 // 系列选项
 export const expansionOptions: Option[] = [
+  { label: "TDM", value: "TDM" },
   { label: "DFT", value: "DFT" },
   { label: "Y25DFT", value: "Y25DFT" },
   { label: "PIO", value: "PIO" },

--- a/lib/store/card.ts
+++ b/lib/store/card.ts
@@ -22,7 +22,7 @@ export const useCardStore = create<CardStore>((set) => ({
   cards: [],
   chineseCards: {},
   params: {
-    expansion: 'DFT',
+    expansion: 'TDM',
     format: 'PremierDraft', 
     start_date: '2016-01-01',
     end_date: today,


### PR DESCRIPTION
- 将系列代号从 'DFT' 更新为 'TDM'。
- 修改当前赛季的开始日期为 '2025-04-08'，结束日期为 '2025-06-10'。
- 将最高等级从 60 提升至 70。
- 在 options.ts 中新增 'TDM' 选项。
- 更新 card.ts 中的扩展选项为 'TDM'。