### PR TITLE
更新活动日历与轮替说明

### DIFF
--- a/components/rotation/content.tsx
+++ b/components/rotation/content.tsx
@@ -175,12 +175,12 @@ export function Content({ currentSetGroups, futureSets, recentBans }: Props) {
             </span>
             与其他IP跨界联动的系列，如魔戒：中洲传说™、最终幻想™等，引入了万智牌以外的世界观和角色。
           </div>
-          <div className="text-sm text-[--muted-foreground]">
+          {/* <div className="text-sm text-[--muted-foreground]">
             <span className="inline-flex items-center rounded-md bg-emerald-400/10 px-2 py-1 text-xs font-medium text-emerald-500 ring-1 ring-inset ring-emerald-400/20 whitespace-nowrap mr-2">
               穿越预兆路
             </span>
             部分联动IP无法上线数字平台，故而在数字平台上以万智牌世界观重新设计，但保持相同的游戏机制。
-          </div>
+          </div> */}
         </div>
       </div>
 

--- a/data/events.ts
+++ b/data/events.ts
@@ -13,7 +13,7 @@ export interface Event {
 }
 
 export const calendarMetadata: CalendarMetadata = {
-  lastUpdated: '2026/04/22',
+  lastUpdated: '2026/05/20',
   announcementUrl: 'https://magic.wizards.com/en/news/mtg-arena/secrets-of-strixhaven-event-schedule',
 };
 
@@ -103,7 +103,7 @@ const premierDraftEvents: Event[] = [
   {
     type: 'premier_draft',
     title: '炼金：斯翠海文',
-    startTime: new Date('2026-05-26T08:00:00-07:00'),
+    startTime: new Date('2026-05-19T08:00:00-07:00'),
     endTime: new Date('2026-06-02T08:00:00-07:00'),
     format: '竞技轮抽'
   },
@@ -226,6 +226,14 @@ const otherEvents: Event[] = [
     endTime: new Date('2026-06-23T08:00:00-07:00'),
     format: '方盒轮抽'
   },
+  {
+    type: 'other',
+    title: '万智牌：基石构筑幻影轮抽',
+    startTime: new Date('2026-06-10T08:00:00-07:00'),
+    endTime: new Date('2026-06-13T08:00:00-07:00'),
+    format: '幻影轮抽',
+    description: '免门票，庆祝国际游戏日'
+  },
 ];
 
 const arenaDirectEvents: Event[] = [
@@ -246,8 +254,8 @@ const arenaDirectEvents: Event[] = [
   {
     type: 'arena_direct',
     title: '竞技场直邮赛 - 斯翠海文的秘密常规补充包',
-    startTime: new Date('2026-05-29T08:00:00-07:00'),
-    endTime: new Date('2026-06-01T08:00:00-07:00'),
+    startTime: new Date('2026-05-27T08:00:00-07:00'),
+    endTime: new Date('2026-05-31T08:00:00-07:00'),
     format: '斯翠海文的秘密现开'
   },
   {

--- a/data/rotation.json
+++ b/data/rotation.json
@@ -432,13 +432,11 @@
       "name": "Marvel’s Spider-Man",
       "codename": null,
       "block": null,
-      "code": "SPM", 
+      "code": "SPM",
       "enter_date": "2025-09-19T00:00:00.000",
       "rough_enter_date": "Q4 2025",
       "exit_date": null,
       "rough_exit_date": "Q1 2028",
-      "digital_name": "Through the Omenpaths",
-      "digital_code": "OM1",
       "universes_beyond": true
     },
     {


### PR DESCRIPTION
- 修正炼金：斯翠海文与竞技场直邮赛日期
- 新增国际游戏日免费幻影轮抽
- 暂时隐藏穿越预兆路说明