### PR TITLE
fix(data): 修复活动日历更新日期不显示的问题

### DIFF
--- a/public/data/events.json
+++ b/public/data/events.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
-    "version": "2026-06-23",
-    "source": "https://magic.wizards.com/en/news/mtg-arena/marvel-super-heroes-event-schedule"
+    "lastUpdated": "2026-06-23",
+    "announcementUrl": "https://magic.wizards.com/en/news/mtg-arena/marvel-super-heroes-event-schedule"
   },
   "groups": [
     {


### PR DESCRIPTION
events.json 的 metadata 字段名与代码期望不一致：原为 version/source， 代码（Web 端 app/calendar/page.tsx 与小程序端 wxapp/pages/calendar） 读取的是 lastUpdated/announcementUrl，导致两端均不显示更新日期。

将字段重命名为 lastUpdated 和 announcementUrl 以匹配代码。