### PR TITLE
fix: 色组切换系列自动设置起始日期并兼容小程序新版卡牌数据

### DIFF
--- a/components/color/color-filters.tsx
+++ b/components/color/color-filters.tsx
@@ -8,7 +8,7 @@ import { DateRangePicker } from "@/components/ui/date-range-picker";
 import { Popper } from "@/components/ui/popper";
 import { parseISO } from 'date-fns';
 import { toExpansionOptions, type PublicOptionsData } from "@/lib/options";
-import { getFormatsForExpansion, getLiveExpansions, loadExpansionMetadata } from "@/lib/filter";
+import { getFormatsForExpansion, getLiveExpansions, getStartDateForExpansion, loadExpansionMetadata } from "@/lib/filter";
 
 interface ColorFiltersProps {
   params: ColorRatingParams;
@@ -74,6 +74,12 @@ export function ColorFilters({
       } else {
         newParams.event_type = formats[0];
       }
+    }
+
+    // 色组数据仍用 date 字段，切换系列时把 start_date 设为新系列的起始日期
+    const startDate = getStartDateForExpansion(expansion);
+    if (startDate) {
+      newParams.start_date = startDate.split('T')[0];
     }
 
     onParamsChange(newParams);

--- a/wxapp/pages/cards/index.js
+++ b/wxapp/pages/cards/index.js
@@ -35,10 +35,12 @@ let deckColorOptions = [];
 let rarityLabels = {};
 let colorOptions = [];
 let rarityOptions = [];
+let timePeriodOptions = [];
 
 const emptyFilterMetadata = {
   formats_by_expansion: {},
   start_dates: {},
+  time_periods: {},
 };
 
 const gradeHelpItems = [
@@ -64,6 +66,7 @@ function applyOptions(options = {}) {
   rarityLabels = options.rarityLabels || {};
   colorOptions = Array.isArray(options.colorOptions) ? options.colorOptions : [];
   rarityOptions = Array.isArray(options.rarityOptions) ? options.rarityOptions : [];
+  timePeriodOptions = Array.isArray(options.timePeriodOptions) ? options.timePeriodOptions : [];
 }
 
 function today() {
@@ -71,7 +74,7 @@ function today() {
 }
 
 function getFilterMetadata(data) {
-  return data && data.formats_by_expansion && data.start_dates ? data : emptyFilterMetadata;
+  return data && data.formats_by_expansion && data.start_dates && data.time_periods ? data : emptyFilterMetadata;
 }
 
 function getAvailableFormatOptions(expansion, metadata = emptyFilterMetadata) {
@@ -86,6 +89,21 @@ function getAvailableFormatOptions(expansion, metadata = emptyFilterMetadata) {
 function getExpansionStartDate(expansion, metadata = emptyFilterMetadata) {
   const value = getFilterMetadata(metadata).start_dates[expansion];
   return value ? String(value).slice(0, 10) : '';
+}
+
+// 获取系列支持的时间段列表
+// 17lands 卡牌数据 API 已用 time_period 替代 start_date/end_date
+function getTimePeriodsForExpansion(expansion, metadata = emptyFilterMetadata) {
+  const periods = getFilterMetadata(metadata).time_periods[expansion];
+  if (Array.isArray(periods) && periods.length) return periods;
+  return getFilterMetadata(metadata).time_periods[''] || [];
+}
+
+function getAvailableTimePeriodOptions(expansion, metadata = emptyFilterMetadata) {
+  const periods = getTimePeriodsForExpansion(expansion, metadata);
+  if (!periods.length) return timePeriodOptions;
+  const options = timePeriodOptions.filter((item) => periods.includes(item.value));
+  return options.length ? options : timePeriodOptions;
 }
 
 function getOptionIndex(options, value) {
@@ -117,6 +135,11 @@ function getDefaultStartDate(expansion, metadata) {
     || '2016-01-01';
 }
 
+function getDefaultTimePeriod(expansion, metadata) {
+  const periods = getTimePeriodsForExpansion(expansion, metadata);
+  return periods.length ? periods[0] : 'ALL_TIME';
+}
+
 function buildInitialState(metadata = emptyFilterMetadata) {
   const expansion = getDefaultExpansion();
   const availableFormatOptions = getAvailableFormatOptions(expansion, metadata);
@@ -124,19 +147,25 @@ function buildInitialState(metadata = emptyFilterMetadata) {
   const formatOption = availableFormatOptions[formatIndex] || availableFormatOptions[0] || formatOptions[0];
   const userGroupValue = '';
   const deckColorValue = '';
+  const timePeriodValue = getDefaultTimePeriod(expansion, metadata);
+  const availableTimePeriodOptions = getAvailableTimePeriodOptions(expansion, metadata);
+  const timePeriodIndex = getOptionIndex(availableTimePeriodOptions, timePeriodValue);
   return {
     filterMetadata: getFilterMetadata(metadata),
     availableFormatOptions,
+    availableTimePeriodOptions,
     params: {
       expansion,
       event_type: formatOption ? formatOption.value : 'PremierDraft',
       user_group: userGroupValue,
       colors: deckColorValue,
+      time_period: timePeriodValue,
       start_date: getDefaultStartDate(expansion, metadata),
       end_date: today(),
     },
     expansionIndex: getExpansionIndex(expansion),
     formatIndex,
+    timePeriodIndex,
     userGroupIndex: getOptionIndex(userGroupOptions, userGroupValue),
     deckColorIndex: getOptionIndex(deckColorOptions, deckColorValue),
     currentSetGlyph: getSetIconGlyph(expansion),
@@ -385,14 +414,34 @@ Page({
     const formatIndex = getFormatIndex(availableFormatOptions, currentFormat);
     const formatOption = availableFormatOptions[formatIndex] || availableFormatOptions[0] || formatOptions[0];
     const startDate = getExpansionStartDate(expansion, this.data.filterMetadata);
+    // 切换系列时，按新系列更新时间段选项；若当前值不可用则回退到第一个可用项
+    const availableTimePeriodOptions = getAvailableTimePeriodOptions(expansion, this.data.filterMetadata);
+    const periods = getTimePeriodsForExpansion(expansion, this.data.filterMetadata);
+    let timePeriodValue = this.data.params.time_period;
+    if (periods.length && !periods.includes(timePeriodValue)) {
+      timePeriodValue = periods[0];
+    }
+    const timePeriodIndex = getOptionIndex(availableTimePeriodOptions, timePeriodValue);
     this.reloadAfterParamChange({
       expansionIndex: index,
       availableFormatOptions,
+      availableTimePeriodOptions,
       formatIndex,
+      timePeriodIndex,
       'params.expansion': expansion,
       'params.event_type': formatOption ? formatOption.value : 'PremierDraft',
+      'params.time_period': timePeriodValue,
       currentSetGlyph: getSetIconGlyph(expansion),
       ...(startDate ? { 'params.start_date': startDate } : {}),
+    });
+  },
+
+  onTimePeriodChange(event) {
+    const index = Number(event.detail.value);
+    const option = this.data.availableTimePeriodOptions[index] || this.data.availableTimePeriodOptions[0];
+    this.reloadAfterParamChange({
+      timePeriodIndex: index,
+      'params.time_period': option ? option.value : 'ALL_TIME',
     });
   },
 
@@ -418,13 +467,6 @@ Page({
     this.reloadAfterParamChange({
       deckColorIndex: index,
       'params.colors': deckColorOptions[index].value,
-    });
-  },
-
-  onDateChange(event) {
-    const { field } = event.currentTarget.dataset;
-    this.reloadAfterParamChange({
-      [`params.${field}`]: event.detail.value,
     });
   },
 

--- a/wxapp/pages/cards/index.wxml
+++ b/wxapp/pages/cards/index.wxml
@@ -10,7 +10,7 @@
         <text wx:if="{{setIconFontReady && currentSetGlyph}}" class="set-rarity query-set-glyph">{{currentSetGlyph}}</text>
         <view class="query-title">{{params.expansion}} · {{availableFormatOptions[formatIndex].label}}</view>
       </view>
-      <view class="query-meta">{{params.start_date}} 至 {{params.end_date}} · {{userGroupOptions[userGroupIndex].label}} · {{deckColorOptions[deckColorIndex].label}}</view>
+      <view class="query-meta">{{availableTimePeriodOptions[timePeriodIndex].label}} · {{userGroupOptions[userGroupIndex].label}} · {{deckColorOptions[deckColorIndex].label}}</view>
     </view>
     <view class="query-actions">
       <view class="icon-action primary-icon-action {{loading ? 'loading' : ''}}" role="button" aria-label="{{loading ? '加载中' : '加载'}}" bindtap="loadCards">
@@ -50,19 +50,11 @@
         </picker>
       </view>
     </view>
-    <view class="date-grid">
-      <view class="field">
-        <view class="label">开始日期</view>
-        <picker mode="date" value="{{params.start_date}}" data-field="start_date" bindchange="onDateChange">
-          <view class="select">{{params.start_date}}</view>
-        </picker>
-      </view>
-      <view class="field">
-        <view class="label">结束日期</view>
-        <picker mode="date" value="{{params.end_date}}" data-field="end_date" bindchange="onDateChange">
-          <view class="select">{{params.end_date}}</view>
-        </picker>
-      </view>
+    <view class="field">
+      <view class="label">时间范围</view>
+      <picker range="{{availableTimePeriodOptions}}" range-key="label" value="{{timePeriodIndex}}" bindchange="onTimePeriodChange">
+        <view class="select">{{availableTimePeriodOptions[timePeriodIndex].label}}</view>
+      </picker>
     </view>
   </view>
 

--- a/wxapp/utils/api.js
+++ b/wxapp/utils/api.js
@@ -79,12 +79,18 @@ function requestWithRetry({ url, data, header, timeout = RETRY_TIMEOUT, retries 
 }
 
 function fetchCardData(params) {
-  const query = Object.keys(params)
+  // 17lands 卡牌数据 API 已用 time_period 替代 start_date/end_date，这里只发送需要的字段
+  const fields = ['expansion', 'event_type', 'time_period', 'user_group', 'colors'];
+  const query = fields
     .filter((key) => params[key] !== undefined && params[key] !== '')
     .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
     .join('&');
   return requestWithRetry({
-    url: `https://www.17lands.com/card_ratings/data?${query}`,
+    url: `https://www.17lands.com/api/card_data?${query}`,
+  }).then((payload) => {
+    // 统一提取 data 字段，兼容两种格式
+    if (Array.isArray(payload)) return payload;
+    return (payload && Array.isArray(payload.data)) ? payload.data : [];
   });
 }
 


### PR DESCRIPTION
- 色组筛选：切换系列时根据 filter.json 的 start_dates 自动更新 start_date
- 小程序卡牌数据：fetchCardData 兼容 17lands 新版 {copyright, data: [...]} 返回结构，统一提取 data 字段
- 小程序 cards 页面同步 time_period 改造（时间段选择器替代日期范围）