### PR TITLE
ci: 用 PAT 拉取私有子模块 shiqidi-edge-functions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: recursive
+          token: ${{ secrets.SUBMODULE_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
actions/checkout 默认的 GITHUB_TOKEN 无跨仓库权限，无法访问私有子模块。 改用 SUBMODULE_TOKEN secret（Fine-grained PAT，仅读 shiqidi-edge-functions） 作为 checkout token，submodules 改为 recursive 确保拉取。