### PR TITLE
ci: 在 prebuild 步骤注入 AFDIAN 凭据环境变量

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Run prebuild script
         run: pnpm prebuild
+        env:
+          AFDIAN_USER_ID: ${{ secrets.AFDIAN_USER_ID }}
+          AFDIAN_TOKEN: ${{ secrets.AFDIAN_TOKEN }}
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
修复 GitHub Actions 跑 build 时 fetch-sponsors.js 读取不到 secrets 的问题：之前 AFDIAN_USER_ID / AFDIAN_TOKEN 只在本地
可直接使用，CI 上需显式注入到 pnpm prebuild step 的 env 块。